### PR TITLE
fixed source name on source map

### DIFF
--- a/tasks/terser.js
+++ b/tasks/terser.js
@@ -9,6 +9,7 @@
 'use strict';
 
 var Terser = require('terser');
+var path = require("path");
 
 module.exports = function(grunt) {
   // Please see the Grunt documentation for more information regarding task
@@ -34,11 +35,16 @@ module.exports = function(grunt) {
               return true;
             }
           })
-          .map(function(filepath) {
+          .reduce(function (sources, filepath) {
             // Read file source.
-            return grunt.file.read(filepath);
-          })
-          .join(';');
+            var destName = path.basename(f.dest);
+            var fileContent = grunt.file.read(filepath);
+            var sourceContent = sources[destName] ? sources[destName] + ';' + fileContent : fileContent;
+
+            return {
+              ...sources, [destName]: sourceContent
+            };
+          }, {});
 
         // Minify file code.
         var result = Terser.minify(src, options);


### PR DESCRIPTION
Create an object with the correct filenames like the one specified in https://github.com/terser/terser#api-reference

![image](https://user-images.githubusercontent.com/484549/66865805-661b0a80-ef6e-11e9-9a2a-dafc23cfc674.png)

Fixes the `sources:["0"]` problem on generated sourceMaps